### PR TITLE
[codex] Require QuantPlatformKit artifact contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crypto-strategies"
-version = "0.4.4"
+version = "0.4.5"
 description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.12",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.16",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- bump crypto-strategies to 0.4.5
- require quant-platform-kit v0.7.16 so StrategyArtifactContract is available in tagged installs

## Validation
- PYTHONPATH=src:/home/ubuntu/Projects/QuantPlatformKit/src /home/ubuntu/Projects/UsEquityStrategies/.venv/bin/python -m unittest tests.test_contract_governance tests.test_catalog tests.test_entrypoints -v
- python3 -m compileall src tests
- python3 -m ruff check .
- git diff --check

## Context
BinancePlatform runtime failed after installing crypto-strategies v0.4.4 with quant-platform-kit v0.7.12 because the older tag does not export StrategyArtifactContract.