### PR TITLE
[codex] Update QPK dependency pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crypto-strategies"
-version = "0.4.6"
+version = "0.4.7"
 description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.17",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@v0.7.35",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- bump package version to 0.4.7
- pin QuantPlatformKit to the released v0.7.35 tag

## Validation
- `timeout 120s env PYTHONPATH=/home/ubuntu/Projects/QuantPlatformKit/src:src python3 -m unittest discover -s tests -v` (passes; 2 pandas-dependent tests skipped locally because pandas is not installed in the system Python)
- GitHub CI installs pandas and runs the full suite
