### PR TITLE
Add bilingual docs summaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `Contributing`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Ground Rules`、`Branching and Pull Requests`、`Local Verification`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Thanks for contributing to `CryptoStrategies`.
 
 ## Ground Rules

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,13 @@
 # Security Policy
 
+
+## 中文摘要
+
+- 用途：本文档围绕 `Security Policy`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Reporting a Vulnerability`、`Secret and Credential Exposure`、`Scope Notes`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Thanks for helping keep `CryptoStrategies` safe.
 
 This repository is part of a shared strategy package. Please do **not** open a public issue for vulnerabilities involving credentials, broker access, cloud resources, order execution, or secret material.

--- a/docs/crypto_cross_platform_strategy_spec.md
+++ b/docs/crypto_cross_platform_strategy_spec.md
@@ -1,5 +1,14 @@
 # Crypto cross-platform strategy spec
 
+
+## 中文摘要
+
+- 完整中文版见 [`crypto_cross_platform_strategy_spec.zh-CN.md`](crypto_cross_platform_strategy_spec.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
+- 用途：本文档围绕 `Crypto cross-platform strategy spec`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Canonical required inputs`、`Target mode`、`Runtime adapters`、`Allowed and forbidden boundaries`、`Current rollout`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 This repository now follows the same contract split used by the US equity stack:
 
 - `CryptoStrategies` owns pure strategy logic, manifests, metadata, and runtime adapters

--- a/docs/crypto_cross_platform_strategy_spec.zh-CN.md
+++ b/docs/crypto_cross_platform_strategy_spec.zh-CN.md
@@ -1,5 +1,15 @@
 # 加密策略跨平台规范
 
+
+## English summary
+
+- Full English version: [`crypto_cross_platform_strategy_spec.md`](crypto_cross_platform_strategy_spec.md). This summary keeps an English entry point in the Chinese file.
+- Purpose: this document covers `加密策略跨平台规范` for `CryptoStrategies`.
+- Main topics: `canonical 输入集合`, `target mode`, `runtime adapter`, `允许和禁止`, `当前落地状态`.
+- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
+- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
+- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+
 这个仓库现在按照美股那套边界来拆：
 
 - `CryptoStrategies` 负责纯策略逻辑、manifest、元数据和 runtime adapter

--- a/docs/crypto_portability_checklist.md
+++ b/docs/crypto_portability_checklist.md
@@ -1,5 +1,14 @@
 # Crypto portability checklist
 
+
+## 中文摘要
+
+- 完整中文版见 [`crypto_portability_checklist.zh-CN.md`](crypto_portability_checklist.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
+- 用途：本文档围绕 `Crypto portability checklist`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Crypto portability checklist`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Use this before enabling a crypto profile on any downstream platform.
 
 - [ ] `required_inputs` only use canonical crypto input names

--- a/docs/crypto_portability_checklist.zh-CN.md
+++ b/docs/crypto_portability_checklist.zh-CN.md
@@ -1,5 +1,15 @@
 # 加密策略 portability 清单
 
+
+## English summary
+
+- Full English version: [`crypto_portability_checklist.md`](crypto_portability_checklist.md). This summary keeps an English entry point in the Chinese file.
+- Purpose: this document covers `加密策略 portability 清单` for `CryptoStrategies`.
+- Main topics: `加密策略 portability 清单`.
+- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
+- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
+- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+
 在某条加密策略真正放到下游平台启用前，先过这张清单。
 
 - [ ] `required_inputs` 只使用 canonical 加密输入名

--- a/docs/crypto_strategy_template.md
+++ b/docs/crypto_strategy_template.md
@@ -1,5 +1,14 @@
 # Crypto strategy template
 
+
+## 中文摘要
+
+- 完整中文版见 [`crypto_strategy_template.zh-CN.md`](crypto_strategy_template.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
+- 用途：本文档围绕 `Crypto strategy template`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
+- 主要覆盖：`Minimum layout`、`Minimum checklist`、`StrategyDefinition`、`Manifest and entrypoint`、`Runtime adapter`。
+- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
+- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
+- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Use this template when adding a new crypto strategy profile.
 
 ## Minimum layout

--- a/docs/crypto_strategy_template.zh-CN.md
+++ b/docs/crypto_strategy_template.zh-CN.md
@@ -1,5 +1,15 @@
 # 加密策略模板
 
+
+## English summary
+
+- Full English version: [`crypto_strategy_template.md`](crypto_strategy_template.md). This summary keeps an English entry point in the Chinese file.
+- Purpose: this document covers `加密策略模板` for `CryptoStrategies`.
+- Main topics: `最小目录结构`, `最小接入清单`, `StrategyDefinition 必填项`, `Manifest 和 entrypoint`, `Runtime adapter`.
+- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
+- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
+- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+
 以后新增加密策略时，按这个模板落。
 
 ## 最小目录结构


### PR DESCRIPTION
## Summary
- Add bilingual summary entry points to repository documentation.
- Keep existing detailed docs intact while adding Chinese or English summaries where missing.
- Add cross-language navigation for paired English / zh-CN docs where available.

## Validation
- Custom bilingual coverage scan: coverage_issues=0.
- git diff --check passed.

## Deployment note
Documentation-only change; no runtime code, secrets, production env, or deployment settings changed.
