### PR TITLE
[codex] Improve open source documentation governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## 中文摘要
+
+- 用途：本文档说明 QuantStrategyLab 仓库中的讨论、issue、pull request 和 review 行为规范。
+- 主要覆盖：`Our Standards`、`Project Scope`、`Reporting and Enforcement`。
+- 阅读顺序：参与讨论或提交 PR 前先确认沟通边界；发现不当行为时联系维护者。
+- 风险提示：涉及投资、交易、密钥或实盘系统的讨论必须保持克制、可复现和证据导向。
+
+## Our Standards
+
+- Be respectful, direct, and evidence-oriented in issues, pull requests, reviews, and discussions.
+- Assume technical disagreement is about the work. Keep feedback specific to code, docs, data, evidence, reproducibility, or operational risk.
+- Avoid harassment, insults, discriminatory language, personal attacks, and repeated off-topic comments.
+- Do not pressure maintainers or contributors to disclose private account details, credentials, trading records, unpublished data, or personal information.
+
+## Project Scope
+
+QuantStrategyLab repositories involve research, automation, strategy artifacts, and trading-support systems. Contributions should keep financial claims conservative and verifiable, separate research evidence from live-trading decisions, and avoid presenting examples as investment advice.
+
+## Reporting and Enforcement
+
+Report conduct concerns to the maintainer on GitHub: `@Pigbibi`. Maintainers may edit or remove comments, close issues or pull requests, restrict participation, or take other reasonable steps to protect contributors and project integrity.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ python -m pytest -q
 - Prefer small, reviewable changes with tests or reproducible evidence.
 - For strategy changes, include the command or artifact used to validate behavior.
 
+## Community and security
+
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for pull request scope, local verification, and documentation expectations.
+- Follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for maintainer and contributor conduct.
+- Report credential, automation, broker, exchange, or cloud-resource vulnerabilities through [SECURITY.md](SECURITY.md); do not open public issues for secrets or live-execution risk.
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,12 @@ python -m pytest -q
 - 改动尽量小，并配套测试或可复现证据。
 - 涉及策略行为的改动，请附上验证命令或产物路径。
 
+## 社区和安全
+
+- 贡献前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)，确认 PR 范围、本地校验和文档要求。
+- 讨论、issue 和 review 请遵守 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
+- 涉及密钥、自动化、券商/交易所或云资源的漏洞请按 [SECURITY.md](SECURITY.md) 私密报告；不要为 secret 或实盘风险开公开 issue。
+
 ## 许可证
 
 详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- add or link standard open-source governance docs from the README
- add CODE_OF_CONDUCT across the repository surface
- add missing CONTRIBUTING and SECURITY docs where this repository did not already have them

## Validation
- git diff --check
- Markdown link check across repository docs