### PR TITLE
Point crypto strategy docs to CryptoLivePoolPipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is one layer of a multi-repository system:
 - **Platform runtimes**: connect strategies to brokers, dry-run checks, notifications, and live deployment controls.
 - **Shared infrastructure**: keeps contracts, settings, adapters, plugins, and audit workflows reusable across repositories.
 
-This repository owns strategy code and metadata. For snapshot-backed crypto profiles, it consumes the upstream live pool and does not rebuild monthly pool membership or ordering locally. It does not hold broker credentials, submit orders by itself, or replace the snapshot/backtest evidence required before a profile is enabled for live runtime settings.
+This repository owns strategy code and metadata. For snapshot-backed crypto profiles, it consumes the upstream live pool and does not rebuild monthly pool membership or ordering locally. It does not hold broker credentials, submit orders by itself, or replace the live-pool/release evidence required before a profile is enabled for live runtime settings.
 
 ## Strategy profiles
 
@@ -27,11 +27,11 @@ No direct runtime strategies are exposed from this package.
 
 ### Snapshot-backed strategies
 
-These profiles depend on artifacts produced by `CryptoSnapshotPipelines` before downstream platforms should use them.
+These profiles depend on artifacts produced by `CryptoLivePoolPipelines` before downstream platforms should use them.
 
 | Profile | Name | Notes |
 | --- | --- | --- |
-| `crypto_leader_rotation` | Crypto Leader Rotation | runtime-enabled trend-following rotation that consumes the ordered live pool published by CryptoSnapshotPipelines. Runtime code may gate and size trades inside that pool, but monthly selection and order remain upstream. |
+| `crypto_leader_rotation` | Crypto Leader Rotation | runtime-enabled trend-following rotation that consumes the ordered live pool published by CryptoLivePoolPipelines. Runtime code may gate and size trades inside that pool, but monthly selection and order remain upstream. |
 
 ### Research-only candidates
 
@@ -47,7 +47,7 @@ Use the platform repositories for broker credentials, dry-run/live switches, ord
 
 ## Evidence and live enablement
 
-Use this README as a map of the project, not as live performance data. Before enabling or changing a live profile, rerun the relevant snapshot/backtest pipeline and review short, medium, and long windows: return, max drawdown, benchmark-relative return, turnover, data freshness, and artifact version. Monthly live-pool selection, ranking, and promotion evidence belong in CryptoSnapshotPipelines; strategy changes here should preserve that upstream authority. If evidence is stale, incomplete, or the profile is marked research-only, keep it out of live runtime settings.
+Use this README as a map of the project, not as live performance data. Before enabling or changing a live profile, rerun the relevant live-pool/release pipeline and review short, medium, and long windows: return, max drawdown, benchmark-relative return, turnover, data freshness, and artifact version. Monthly live-pool selection, ranking, and promotion evidence belong in CryptoLivePoolPipelines; strategy changes here should preserve that upstream authority. If evidence is stale, incomplete, or the profile is marked research-only, keep it out of live runtime settings.
 
 ## Repository layout
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@ CryptoStrategies 是 QuantStrategyLab 的加密货币策略包。为 Binance 执
 - **执行平台**：把策略接到券商、dry-run 检查、通知和 live 部署控制。
 - **共享基础设施**：沉淀契约、配置、适配器、插件和审计 workflow，供多仓复用。
 
-本仓库负责策略代码和元数据。对 snapshot-backed 加密策略来说，本仓库只消费上游 live pool，不在本地重建月度池成员或顺序。本仓库不保存券商凭据，不直接提交订单，也不替代 live enable 前需要看的 snapshot 和回测证据。
+本仓库负责策略代码和元数据。对 snapshot-backed 加密策略来说，本仓库只消费上游 live pool，不在本地重建月度池成员或顺序。本仓库不保存券商凭据，不直接提交订单，也不替代 live enable 前需要看的 live-pool/release 证据。
 
 ## 策略 profile
 
@@ -27,11 +27,11 @@ CryptoStrategies 是 QuantStrategyLab 的加密货币策略包。为 Binance 执
 
 ### Snapshot-backed 策略
 
-这些 profile 依赖 `CryptoSnapshotPipelines` 生成的 artifact；下游平台使用前，应先确认对应产物已经验证和提升。
+这些 profile 依赖 `CryptoLivePoolPipelines` 生成的 artifact；下游平台使用前，应先确认对应产物已经验证和提升。
 
 | Profile | 名称 | 说明 |
 | --- | --- | --- |
-| `crypto_leader_rotation` | Crypto Leader Rotation | 消费 CryptoSnapshotPipelines 发布的有序 live pool 的趋势轮动策略。运行时代码可以在该池内做交易门控和仓位 sizing，但月度选池和排序属于上游。 |
+| `crypto_leader_rotation` | Crypto Leader Rotation | 消费 CryptoLivePoolPipelines 发布的有序 live pool 的趋势轮动策略。运行时代码可以在该池内做交易门控和仓位 sizing，但月度选池和排序属于上游。 |
 
 ### 研究侧候选
 
@@ -47,7 +47,7 @@ CryptoStrategies 是 QuantStrategyLab 的加密货币策略包。为 Binance 执
 
 ## 策略证据和 live enablement
 
-README 只作为项目地图，不替代最新表现数据。启用或调整 live profile 前，需要重新运行相关 snapshot/backtest pipeline，并分别看短、中、长周期的收益、最大回撤、相对基准收益、换手、数据新鲜度和 artifact 版本。月度 live-pool 选择、ranking 和 promotion 证据属于 CryptoSnapshotPipelines；本仓库的策略改动应保留这个上游权威边界。证据过期、不完整，或者 profile 仍标记为 research-only，就不要放进 live runtime settings。
+README 只作为项目地图，不替代最新表现数据。启用或调整 live profile 前，需要重新运行相关 live-pool/release pipeline，并分别看短、中、长周期的收益、最大回撤、相对基准收益、换手、数据新鲜度和 artifact 版本。月度 live-pool 选择、ranking 和 promotion 证据属于 CryptoLivePoolPipelines；本仓库的策略改动应保留这个上游权威边界。证据过期、不完整，或者 profile 仍标记为 research-only，就不要放进 live runtime settings。
 
 ## 仓库结构
 

--- a/docs/crypto_cross_platform_strategy_spec.md
+++ b/docs/crypto_cross_platform_strategy_spec.md
@@ -32,7 +32,7 @@ Current meaning for the live profile:
 - `derived_indicators`: strategy-ready trend metrics keyed by symbol
 - `benchmark_snapshot`: benchmark regime snapshot, currently BTC
 - `portfolio_snapshot`: exchange-agnostic portfolio and cash snapshot
-- `universe_snapshot`: ordered official live-pool symbols from the validated `CryptoSnapshotPipelines` artifact for this cycle
+- `universe_snapshot`: ordered official live-pool symbols from the validated `CryptoLivePoolPipelines` artifact for this cycle
 
 ## Target mode
 
@@ -68,7 +68,7 @@ profile-name branches.
 
 ## Live-pool authority boundary
 
-For `crypto_leader_rotation`, `CryptoSnapshotPipelines` is the authority for monthly live-pool membership, ranking, and order. The execution platform validates and preserves the ordered `live_pool.json["symbols"]` list, then passes it into `StrategyContext.market_data["universe_snapshot"]`.
+For `crypto_leader_rotation`, `CryptoLivePoolPipelines` is the authority for monthly live-pool membership, ranking, and order. The execution platform validates and preserves the ordered `live_pool.json["symbols"]` list, then passes it into `StrategyContext.market_data["universe_snapshot"]`.
 
 Strategy code may apply runtime gates, sell rules, top-N selection, inverse-volatility sizing, BTC core allocation, and buy-budget allocation inside that upstream pool. It must not rebuild the monthly live pool from local indicators, replace the upstream order with a local ranking, or treat research CSVs as a substitute for the validated artifact contract.
 

--- a/docs/crypto_cross_platform_strategy_spec.zh-CN.md
+++ b/docs/crypto_cross_platform_strategy_spec.zh-CN.md
@@ -33,7 +33,7 @@
 - `derived_indicators`：按 symbol 组织的策略级趋势指标
 - `benchmark_snapshot`：基准状态快照，当前是 BTC
 - `portfolio_snapshot`：与交易所无关的组合和现金快照
-- `universe_snapshot`：来自已验证 `CryptoSnapshotPipelines` artifact 的本轮官方有序 live-pool 标的集合
+- `universe_snapshot`：来自已验证 `CryptoLivePoolPipelines` artifact 的本轮官方有序 live-pool 标的集合
 
 ## target mode
 
@@ -67,7 +67,7 @@
 
 ## live-pool 权威边界
 
-对 `crypto_leader_rotation` 来说，`CryptoSnapshotPipelines` 是月度 live pool 成员、ranking 和顺序的权威来源。执行平台负责校验并保留 `live_pool.json["symbols"]` 的有序列表，然后把它传给 `StrategyContext.market_data["universe_snapshot"]`。
+对 `crypto_leader_rotation` 来说，`CryptoLivePoolPipelines` 是月度 live pool 成员、ranking 和顺序的权威来源。执行平台负责校验并保留 `live_pool.json["symbols"]` 的有序列表，然后把它传给 `StrategyContext.market_data["universe_snapshot"]`。
 
 策略代码可以在这个上游池内做运行时门控、卖出规则、top-N 选择、逆波动 sizing、BTC core allocation 和买入预算分配。策略代码不能用本地指标重建月度 live pool，不能用本地 ranking 替换上游顺序，也不能把 research CSV 当作已验证 artifact contract 的替代品。
 


### PR DESCRIPTION
Summary:
- Replace CryptoSnapshotPipelines references with CryptoLivePoolPipelines.
- Tighten evidence wording from snapshot/backtest pipeline to live-pool/release pipeline for the crypto live profile.

Tests:
- timeout 120 env PYTHONPATH=src:/home/ubuntu/Projects/QuantPlatformKit/src /usr/bin/python3 -m unittest tests.test_catalog tests.test_contract_governance -v
- Result: OK.