### PR TITLE
Polish bilingual documentation

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@ CryptoStrategies 是 QuantStrategyLab 的加密货币策略包。为 Binance 执
 - **策略包**：保存可复用策略代码、元数据和运行入口。
 - **Snapshot 流水线**：生成官方 live-pool snapshot、ranking、回测和发布证据。
 - **执行平台**：把策略接到券商、dry-run 检查、通知和 live 部署控制。
-- **共享基础设施**：沉淀契约、配置、适配器、插件和审计 workflow，供多仓复用。
+- **共享基础设施**：维护契约、配置、适配器、插件和审计 workflow，供多仓复用。
 
 本仓库负责策略代码和元数据。对 snapshot-backed 加密策略来说，本仓库只消费上游 live pool，不在本地重建月度池成员或顺序。本仓库不保存券商凭据，不直接提交订单，也不替代 live enable 前需要看的 live-pool/release 证据。
 

--- a/docs/crypto_cross_platform_strategy_spec.md
+++ b/docs/crypto_cross_platform_strategy_spec.md
@@ -1,14 +1,7 @@
 # Crypto cross-platform strategy spec
 
+[简体中文](crypto_cross_platform_strategy_spec.zh-CN.md)
 
-## 中文摘要
-
-- 完整中文版见 [`crypto_cross_platform_strategy_spec.zh-CN.md`](crypto_cross_platform_strategy_spec.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
-- 用途：本文档围绕 `Crypto cross-platform strategy spec`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
-- 主要覆盖：`Canonical required inputs`、`Target mode`、`Runtime adapters`、`Allowed and forbidden boundaries`、`Current rollout`。
-- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
-- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
-- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 This repository now follows the same contract split used by the US equity stack:
 
 - `CryptoStrategies` owns pure strategy logic, manifests, metadata, and runtime adapters

--- a/docs/crypto_cross_platform_strategy_spec.zh-CN.md
+++ b/docs/crypto_cross_platform_strategy_spec.zh-CN.md
@@ -1,14 +1,6 @@
 # 加密策略跨平台规范
 
-
-## English summary
-
-- Full English version: [`crypto_cross_platform_strategy_spec.md`](crypto_cross_platform_strategy_spec.md). This summary keeps an English entry point in the Chinese file.
-- Purpose: this document covers `加密策略跨平台规范` for `CryptoStrategies`.
-- Main topics: `canonical 输入集合`, `target mode`, `runtime adapter`, `允许和禁止`, `当前落地状态`.
-- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
-- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
-- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+[English](crypto_cross_platform_strategy_spec.md)
 
 这个仓库现在按照美股那套边界来拆：
 

--- a/docs/crypto_portability_checklist.md
+++ b/docs/crypto_portability_checklist.md
@@ -1,14 +1,7 @@
 # Crypto portability checklist
 
+[简体中文](crypto_portability_checklist.zh-CN.md)
 
-## 中文摘要
-
-- 完整中文版见 [`crypto_portability_checklist.zh-CN.md`](crypto_portability_checklist.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
-- 用途：本文档围绕 `Crypto portability checklist`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
-- 主要覆盖：`Crypto portability checklist`。
-- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
-- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
-- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Use this before enabling a crypto profile on any downstream platform.
 
 - [ ] `required_inputs` only use canonical crypto input names

--- a/docs/crypto_portability_checklist.zh-CN.md
+++ b/docs/crypto_portability_checklist.zh-CN.md
@@ -1,14 +1,6 @@
 # 加密策略 portability 清单
 
-
-## English summary
-
-- Full English version: [`crypto_portability_checklist.md`](crypto_portability_checklist.md). This summary keeps an English entry point in the Chinese file.
-- Purpose: this document covers `加密策略 portability 清单` for `CryptoStrategies`.
-- Main topics: `加密策略 portability 清单`.
-- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
-- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
-- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+[English](crypto_portability_checklist.md)
 
 在某条加密策略真正放到下游平台启用前，先过这张清单。
 

--- a/docs/crypto_strategy_template.md
+++ b/docs/crypto_strategy_template.md
@@ -1,14 +1,7 @@
 # Crypto strategy template
 
+[简体中文](crypto_strategy_template.zh-CN.md)
 
-## 中文摘要
-
-- 完整中文版见 [`crypto_strategy_template.zh-CN.md`](crypto_strategy_template.zh-CN.md)；本节保留在英文文件顶部，方便从当前文件直接找到中文入口。
-- 用途：本文档围绕 `Crypto strategy template`，用于理解 `CryptoStrategies` 的配置、运行、部署、研究或验收边界。
-- 主要覆盖：`Minimum layout`、`Minimum checklist`、`StrategyDefinition`、`Manifest and entrypoint`、`Runtime adapter`。
-- 阅读顺序：先确认边界、输入输出和权限要求，再执行文档里的命令、CI、dry-run、发布或切换步骤。
-- 风险提示：涉及实盘、密钥、权限、Cloud Run、交易所或券商 API 的变更，必须先在测试环境或 dry-run 验证；不要只凭示例直接修改生产。
-- 英文正文保留更完整的命令、字段名和配置键；如果摘要和正文不一致，以正文中的实际命令和配置为准。
 Use this template when adding a new crypto strategy profile.
 
 ## Minimum layout

--- a/docs/crypto_strategy_template.zh-CN.md
+++ b/docs/crypto_strategy_template.zh-CN.md
@@ -1,14 +1,6 @@
 # 加密策略模板
 
-
-## English summary
-
-- Full English version: [`crypto_strategy_template.md`](crypto_strategy_template.md). This summary keeps an English entry point in the Chinese file.
-- Purpose: this document covers `加密策略模板` for `CryptoStrategies`.
-- Main topics: `最小目录结构`, `最小接入清单`, `StrategyDefinition 必填项`, `Manifest 和 entrypoint`, `Runtime adapter`.
-- Read the boundaries, inputs, outputs, and permission requirements before running commands, CI jobs, dry-runs, releases, or runtime switches.
-- For live trading, secrets, Cloud Run, exchange, or broker API changes, validate in test or dry-run mode first and do not change production only from examples.
-- If this summary differs from the detailed Chinese body, follow the concrete commands, configuration keys, and constraints in the body.
+[English](crypto_strategy_template.md)
 
 以后新增加密策略时，按这个模板落。
 


### PR DESCRIPTION
## Summary
- remove generated cross-language summary blocks from Markdown docs
- keep concise language-switch links where paired docs exist
- tighten a few long or stale bilingual doc passages

## Checks
- `rg "## 中文摘要|## English summary|This summary keeps an English entry point|用于理解 .* 的配置、运行、部署、研究或验收边界"` returns no matches in reviewed docs
- local language-link target check
- `git diff --check`