### PR TITLE
chore: bump quant-platform-kit to bc5351d

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crypto-strategies"
-version = "0.4.8"
+version = "0.4.9"
 description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@aee8121d530c2e92c72b68aee434bf174b3b9c85",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@bc5351d3567b2bb60416dc969062c37eedbbf65e",
 ]
 
 [tool.setuptools]
@@ -19,4 +19,4 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "0.4.9"


### PR DESCRIPTION
Align strategy package with platform kit 0.7.39 for resolve_dry_run_env and execution_state.

Made with [Cursor](https://cursor.com)