### PR TITLE
fix: restore ruff target-version py311

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.ruff]
-target-version = "0.4.9"
+target-version = "py311"


### PR DESCRIPTION
Accidental sed replaced [tool.ruff] target-version with package version.

Made with [Cursor](https://cursor.com)