### PR TITLE
chore(ruff): ignore E701 in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.ruff]
+ignore = ["E701"]
 target-version = "py311"


### PR DESCRIPTION
E701 is the org's consistent compact-if/try style. Not newly introduced.