### PR TITLE
chore: sync QPK dependency SHA across repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@86f03fb8e83c0d372f4e1c64cccf3e6da50b8dd4",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@780b6f8da6a6f7419a12c8f909a415624c98f8eb",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Use consistent QPK SHA to prevent pip resolution conflicts.