### PR TITLE
ci/security/test: automated audit fixes for CryptoStrategies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.ruff]
-ignore = ["E701", "E702", "E741", "F841", "F821", "B008", "F401", "F601", "E402"]
 target-version = "py311"
+
+[tool.ruff.lint]
+ignore = ["E701", "E702", "E741", "F841", "F821", "B008", "F401", "F601", "E402"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Summary
- migrate deprecated top-level Ruff `ignore` settings into `tool.ruff.lint.ignore`

## Problems found
- `ruff check .` emitted a deprecation warning because `ignore` was configured at the top-level Ruff section

## Fixes applied
- moved `ignore` from `[tool.ruff]` to `[tool.ruff.lint]`

## Security impact
- none; lint configuration only

## Architecture impact
- none; no runtime or strategy logic changed

## Tests run
- `.venv/bin/python -m pip check`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m build`
- `actionlint`
- `git diff --check`

## Failed or skipped checks with reasons
- none

## Deployment notes
- no deployment required

## Rollback plan
- revert commit `addce2d`

## Manual follow-up checklist
- [ ] confirm PR checks pass
- [ ] merge after branch protection requirements are satisfied
