### PR TITLE
chore: bump qsl compat bundle to 2026.07.1

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -2,7 +2,7 @@ tier = "strategy-library"
 ring = 1
 
 [compat]
-bundle = "2026.07.0"
+bundle = "2026.07.1"
 requires = [
   "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@0063af3b4a974650ea58a7d3f26dd1b94f65d3e8",
 ]

--- a/tests/test_qsl_compat_metadata.py
+++ b/tests/test_qsl_compat_metadata.py
@@ -8,4 +8,4 @@ def test_qsl_compat_metadata_exists_and_bundle() -> None:
     with qsl_path.open("rb") as f:
         data = tomllib.load(f)
 
-    assert data.get("compat", {}).get("bundle") == "2026.07.0", "compat.bundle mismatch"
+    assert data.get("compat", {}).get("bundle") == "2026.07.1", "compat.bundle mismatch"


### PR DESCRIPTION
Phase-2 QSL compatibility update:\n\n- bump qsl.compat.bundle to 2026.07.1\n- keep tier/ring unchanged\n- strategy repos同步 qsl 兼容测试常量\n- QuantPlatformKit 保留 allow_legacy=true，并保留 legacy_reason 注释（constraints 仍用于 QPK pin 工作流）\n- validation: uv sync --frozen, uv lock --check, uv run --with pytest metadata test, uv run --with ruff ruff check .\n\nGenerated by Codex.