### PR TITLE
[codex] clarify QSL architecture role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # CryptoStrategies
 
+
+## QSL architecture role
+
+- **Layer**: `strategy-library`.
+- **Responsibility**: crypto strategy implementation package.
+- **Owns**: runtime strategy code and metadata consumed by BinancePlatform.
+- **Consumes**: QuantPlatformKit and CryptoLivePoolPipelines artifacts.
+- **Must not**: own broker credentials or execution deployment.
+
 [Chinese README](README.zh-CN.md)
 
 > Investing involves risk. This project does not provide investment advice and is for education, research, and engineering review only.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,14 @@
 # CryptoStrategies
 
+
+## QSL 架构角色
+
+- **层级**：`策略库`。
+- **职责**：加密策略实现包。
+- **事实源/归属**：BinancePlatform 消费的 runtime 策略代码和元数据。
+- **消费对象**：QuantPlatformKit 和 CryptoLivePoolPipelines artifacts。
+- **禁止事项**：持有券商凭据或执行部署。
+
 [English README](README.md)
 
 > 投资有风险。本项目不构成投资建议，仅用于学习、研究和工程审阅。


### PR DESCRIPTION
## Summary
- Add standard QSL architecture role sections to English and Chinese READMEs.

## Validation
- Verified all 24 QuantStrategyLab README pairs contain the new QSL architecture role section.

## Risk
- Documentation-only for this repository unless noted above.
- No secrets, broker credentials, or live order settings are changed.
