### PR TITLE
feat(risk): wire QPK stop-loss diagnostics (task 8)

### DIFF
--- a/src/crypto_strategies/entrypoints/__init__.py
+++ b/src/crypto_strategies/entrypoints/__init__.py
@@ -261,7 +261,7 @@ def evaluate_crypto_live_pool_rotation(ctx: StrategyContext) -> StrategyDecision
         risk_flags=risk_flags,
         diagnostics=diagnostics,
     )
-    decision = apply_risk_gate(decision)
+    decision = apply_risk_gate(decision, ctx=ctx)
     record_strategy_decision(
         ctx,
         decision,
@@ -350,7 +350,7 @@ def evaluate_crypto_btc_dca(ctx: StrategyContext) -> StrategyDecision:
         risk_flags=risk_flags,
         diagnostics=diagnostics,
     )
-    decision = apply_risk_gate(decision, max_single_weight=0.50)
+    decision = apply_risk_gate(decision, ctx=ctx, max_single_weight=0.50)
     record_strategy_decision(
         ctx,
         decision,
@@ -440,7 +440,7 @@ def evaluate_crypto_trend_rotation(ctx: StrategyContext) -> StrategyDecision:
         risk_flags=risk_flags,
         diagnostics=diagnostics,
     )
-    decision = apply_risk_gate(decision, max_single_weight=0.30)
+    decision = apply_risk_gate(decision, ctx=ctx, max_single_weight=0.30)
     record_strategy_decision(
         ctx,
         decision,
@@ -636,7 +636,7 @@ def evaluate_crypto_equity_combo(ctx: StrategyContext) -> StrategyDecision:
         risk_flags=risk_flags,
         diagnostics=diagnostics,
     )
-    decision = apply_risk_gate(decision, max_single_weight=0.30)
+    decision = apply_risk_gate(decision, ctx=ctx, max_single_weight=0.30)
     record_strategy_decision(
         ctx,
         decision,

--- a/src/crypto_strategies/entrypoints/_common.py
+++ b/src/crypto_strategies/entrypoints/_common.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
-from quant_platform_kit.strategy_contracts import PositionTarget, StrategyDecision
+from quant_platform_kit.risk.gate import apply_risk_gate as _qpk_apply_risk_gate
+from quant_platform_kit.risk.gate import enrich_decision_risk_diagnostics
+from quant_platform_kit.risk.portfolio_diagnostics import extract_portfolio_risk_diagnostics
+from quant_platform_kit.strategy_contracts import PositionTarget, StrategyContext, StrategyDecision
 from quant_platform_kit.strategy_lifecycle.performance_monitor import PerformanceMonitor
 
 logger = logging.getLogger(__name__)
@@ -40,105 +45,34 @@ def record_strategy_decision(
         logger.warning("PerformanceMonitor.record failed: %s", exc)
 
 
-def _position_weight(position: PositionTarget) -> float | None:
-    if position.target_weight is not None:
-        return abs(float(position.target_weight))
-    return None
-
-
-def _reject_risk_gate(
-    decision: StrategyDecision,
-    *,
-    risk_flag: str,
-    reason: str,
-) -> StrategyDecision:
-    return StrategyDecision(
-        positions=(),
-        budgets=decision.budgets,
-        risk_flags=(*decision.risk_flags, risk_flag),
-        diagnostics={
-            **(decision.diagnostics or {}),
-            "risk_gate": "REJECT",
-            "reason": reason,
-        },
-    )
-
-
 def apply_risk_gate(
     decision: StrategyDecision,
     *,
+    ctx: StrategyContext | None = None,
     max_single_weight: float = 1.0,
     max_positions: int = 20,
     max_total_exposure: float = 1.0,
+    portfolio_snapshot: Any | None = None,
+    market_data: Mapping[str, Any] | None = None,
 ) -> StrategyDecision:
-    """对所有 StrategyDecision 施加硬风控门。
-
-    检查项：
-    1. 单仓位集中度（> max_single_weight → REJECT，默认 100% 即不限制）
-    2. 持仓数量（> max_positions → REJECT）
-    3. 总仓位超限（> max_total_exposure → REJECT）
-
-    各策略类型可根据自身特点调整门限：
-    - ETF 轮动：max_single_weight=1.0（ETF 本身就是分散的篮子）
-    - 个股精选：max_single_weight=0.10
-    - 加密货币：max_single_weight=0.20, max_positions=10
-
-    如果 REJECT，返回空仓决策并标注拒绝原因。
-    这个函数不可绕过 —— AGENTS.md 要求所有 entrypoint 必须调用。
-    """
-    positions = decision.positions or ()
-
-    if not positions:
-        return StrategyDecision(
-            positions=decision.positions,
-            budgets=decision.budgets,
-            risk_flags=decision.risk_flags,
-            diagnostics={**(decision.diagnostics or {}), "risk_gate": "APPROVE"},
-        )
-
-    weight_positions = [p for p in positions if _position_weight(p) is not None]
-
-    if max_single_weight < 1.0 and weight_positions:
-        for p in weight_positions:
-            weight = _position_weight(p)
-            assert weight is not None
-            if weight > max_single_weight:
-                logger.warning(
-                    "risk_gate REJECT concentration: symbol=%s weight=%.2f%% limit=%.0f%%",
-                    p.symbol, weight * 100, max_single_weight * 100,
-                )
-                return _reject_risk_gate(
-                    decision,
-                    risk_flag="rejected:concentration",
-                    reason=f"{p.symbol} {weight:.1%} > {max_single_weight:.0%} 上限",
-                )
-
-    if len(positions) > max_positions:
-        logger.warning(
-            "risk_gate REJECT position_count: %d > %d", len(positions), max_positions,
-        )
-        return _reject_risk_gate(
+    """QPK unified risk gate: stop-loss, circuit breaker, concentration (task 8)."""
+    snapshot = portfolio_snapshot if portfolio_snapshot is not None else (
+        ctx.portfolio if ctx is not None else None
+    )
+    if snapshot is not None:
+        portfolio_diag = extract_portfolio_risk_diagnostics(snapshot)
+        decision = enrich_decision_risk_diagnostics(
             decision,
-            risk_flag="rejected:too_many_positions",
-            reason=f"{len(positions)} 个持仓 > {max_positions} 上限",
+            unrealized_pnl_pct=portfolio_diag.get("unrealized_pnl_pct"),
+            consecutive_losses=portfolio_diag.get("consecutive_losses"),
         )
-
-    if weight_positions:
-        total_weight = sum(_position_weight(p) or 0.0 for p in weight_positions)
-        if total_weight > max_total_exposure + 1e-9:
-            logger.warning(
-                "risk_gate REJECT total_exposure: %.2f%% > %.0f%%",
-                total_weight * 100, max_total_exposure * 100,
-            )
-            return _reject_risk_gate(
-                decision,
-                risk_flag="rejected:overexposed",
-                reason=f"总仓位 {total_weight:.1%} > {max_total_exposure:.0%}",
-            )
-
-    return StrategyDecision(
-        positions=decision.positions,
-        budgets=decision.budgets,
-        risk_flags=decision.risk_flags,
-        diagnostics={**(decision.diagnostics or {}), "risk_gate": "APPROVE"},
+    if market_data is None and ctx is not None:
+        market_data = dict(ctx.market_data or {})
+    return _qpk_apply_risk_gate(
+        decision,
+        max_single_weight=max_single_weight,
+        max_positions=max_positions,
+        max_total_exposure=max_total_exposure,
+        portfolio_snapshot=snapshot,
+        market_data=market_data,
     )

--- a/tests/test_entrypoint_risk_gate.py
+++ b/tests/test_entrypoint_risk_gate.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from quant_platform_kit.common.models import PortfolioSnapshot, Position
+from quant_platform_kit.strategy_contracts import PositionTarget, StrategyContext, StrategyDecision
+
+from crypto_strategies.entrypoints._common import apply_risk_gate
+
+
+def test_apply_risk_gate_enriches_stop_loss_diagnostics_from_portfolio() -> None:
+    snapshot = PortfolioSnapshot(
+        as_of=datetime(2026, 7, 9, tzinfo=timezone.utc),
+        total_equity=1000.0,
+        positions=(
+            Position(symbol="BTCUSDT", quantity=1.0, market_value=700.0, average_cost=1000.0),
+        ),
+        metadata={"consecutive_losses": 2},
+    )
+    ctx = StrategyContext(as_of=snapshot.as_of, portfolio=snapshot, market_data={}, state={}, runtime_config={})
+    decision = StrategyDecision(positions=(PositionTarget(symbol="BTCUSDT", target_weight=0.5),))
+    result = apply_risk_gate(decision, ctx=ctx)
+    assert result.positions == ()
+    assert "rejected:stop_loss" in result.risk_flags


### PR DESCRIPTION
## Summary
- Delegate `apply_risk_gate` to QPK unified gate (stop-loss -20%, consecutive-loss circuit breaker)
- Enrich decisions from `ctx.portfolio` via `extract_portfolio_risk_diagnostics` before gating
- Pass `ctx=ctx` from all entrypoints; add regression tests

## Test plan
- [ ] CI `test` job passes
- [ ] `tests/test_entrypoint_risk_gate.py` covers stop-loss reject path

Made with [Cursor](https://cursor.com)