### PR TITLE
chore(qsl): align canonical strategy metadata

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -1,8 +1,8 @@
-tier = "strategy-library"
-ring = 1
+tier = "strategy-lib"
+upgrade_ring = "ring_b"
 
 [compat]
-bundle = "2026.07.2"
+bundle = "2026.07.3"
 requires = [
   "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@37c81901160c5b31127a27dba1c63944933fb6bf",
 ]

--- a/tests/test_qsl_compat_metadata.py
+++ b/tests/test_qsl_compat_metadata.py
@@ -8,4 +8,4 @@ def test_qsl_compat_metadata_exists_and_bundle() -> None:
     with qsl_path.open("rb") as f:
         data = tomllib.load(f)
 
-    assert data.get("compat", {}).get("bundle") == "2026.07.2", "compat.bundle mismatch"
+    assert data.get("compat", {}).get("bundle") == "2026.07.3", "compat.bundle mismatch"


### PR DESCRIPTION
Part of the QuantStrategyLab P0-P5 hardening and convergence wave.

Highlights:
- tighten governance / QSL metadata / runtime reporting where applicable
- keep changes minimal and repository-scoped

Local validation was run before push in the Codex execution session.
