### PR TITLE
ci: add Codex review gate

### DIFF
--- a/.github/workflows/codex_pr_review.yml
+++ b/.github/workflows/codex_pr_review.yml
@@ -22,7 +22,8 @@ jobs:
       allow_unconfigured_backend: false
       api_fallback_enabled: "false"
       direct_api_primary_enabled: "false"
-    secrets: inherit
+    secrets:
+      CODEX_AUDIT_SERVICE_URL: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/codex_pr_review.yml
+++ b/.github/workflows/codex_pr_review.yml
@@ -1,0 +1,30 @@
+name: Codex PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: codex-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: QuantStrategyLab/AIAuditBridge/.github/workflows/codex_pr_review.yml@main
+    with:
+      caller_concurrency_key: pr-${{ github.event.pull_request.number || github.run_id }}
+      allow_unconfigured_backend: false
+      api_fallback_enabled: "false"
+      direct_api_primary_enabled: "false"
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write

--- a/.github/workflows/codex_review_gate.yml
+++ b/.github/workflows/codex_review_gate.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: codex-review-gate-${{ github.event.pull_request.number }}
+  group: codex-review-gate-${{ github.event.pull_request.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Add the organization-standard reusable Codex review wrapper. It runs from the trusted base branch with OIDC and both API fallback paths explicitly disabled; it does not execute PR head content.\n\nValidation: `actionlint .github/workflows/codex_pr_review.yml`; `git diff --check`.