### PR TITLE
chore(deps): align QPK pin to 2dee23c125c0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@31892425a02242126265ac07a626d98796daa459",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2dee23c125c0b1b60946b3bf9e48ce75991bba36",
 ]
 
 [tool.setuptools]

--- a/qsl.toml
+++ b/qsl.toml
@@ -4,5 +4,5 @@ upgrade_ring = "ring_b"
 [compat]
 bundle = "2026.07.3"
 requires = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@31892425a02242126265ac07a626d98796daa459",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2dee23c125c0b1b60946b3bf9e48ce75991bba36",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,9 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=31892425a02242126265ac07a626d98796daa459" }]
+requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2dee23c125c0b1b60946b3bf9e48ce75991bba36" }]
 
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=31892425a02242126265ac07a626d98796daa459#31892425a02242126265ac07a626d98796daa459" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2dee23c125c0b1b60946b3bf9e48ce75991bba36#2dee23c125c0b1b60946b3bf9e48ce75991bba36" }


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `2dee23c125c0`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code