### PR TITLE
fix: restore crypto lifecycle artifact access

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Download latest trusted lifecycle inputs
         id: snapshot-input
         env:
-          GH_TOKEN: ${{ secrets.SNAPSHOT_REPOSITORY_TOKEN }}
+          GH_TOKEN: ${{ secrets.SNAPSHOT_REPOSITORY_TOKEN || secrets.QSL_REPO_SYNC_TOKEN }}
           INPUT_ROOT: ${{ runner.temp }}/crypto-lifecycle-inputs
         run: |
           set -euo pipefail
@@ -212,4 +212,4 @@ jobs:
       lifecycle_preflight_artifact: lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}
     secrets:
       codex_audit_service_url: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}
-      snapshot_repository_token: ${{ secrets.SNAPSHOT_REPOSITORY_TOKEN }}
+      snapshot_repository_token: ${{ secrets.SNAPSHOT_REPOSITORY_TOKEN || secrets.QSL_REPO_SYNC_TOKEN }}

--- a/tests/test_drift_workflow_config.py
+++ b/tests/test_drift_workflow_config.py
@@ -35,4 +35,4 @@ def test_drift_workflow_wires_real_pipeline_inputs_and_preflight_bundle() -> Non
     assert "snapshot_checkout_path: external/CryptoLivePoolPipelines" in workflow
     assert "lifecycle_preflight_artifact: lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
     assert "codex_audit_service_url: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}" in workflow
-    assert "snapshot_repository_token: ${{ secrets.SNAPSHOT_REPOSITORY_TOKEN }}" in workflow
+    assert "secrets.SNAPSHOT_REPOSITORY_TOKEN || secrets.QSL_REPO_SYNC_TOKEN" in workflow


### PR DESCRIPTION
## Summary
- prefer the dedicated snapshot token when configured
- fall back to the existing organization repo-sync token for private cross-repo artifact access
- preserve the same token for the pinned producer checkout

## Validation
- `PYTHONPATH=src:../QuantPlatformKit/src python3 -m pytest -q tests/test_drift_workflow_config.py`
- `actionlint .github/workflows/drift-check.yml`
- `git diff --check`