### PR TITLE
fix: pin public snapshot checkout workflow

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: QuantStrategyLab/QuantPlatformKit
-          ref: bda6afdab0a2dd693c35d14493176829f4da1231
+          ref: 3d14b9697c85ab6d8d990c7a6ea74cc28f18cbf7
           path: external/QuantPlatformKit
 
       - name: Set up Python
@@ -199,7 +199,7 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@bda6afdab0a2dd693c35d14493176829f4da1231
+    uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@3d14b9697c85ab6d8d990c7a6ea74cc28f18cbf7
     with:
       strategy_domain: crypto
       caller_event_name: ${{ github.event_name }}
@@ -208,7 +208,7 @@ jobs:
       snapshot_checkout_path: external/CryptoLivePoolPipelines
       snapshot_repository_ref: ${{ needs.preflight_backtests.outputs.snapshot_repository_ref }}
       ai_gateway_service_url: ${{ vars.AI_GATEWAY_SERVICE_URL }}
-      quant_platform_kit_ref: bda6afdab0a2dd693c35d14493176829f4da1231
+      quant_platform_kit_ref: 3d14b9697c85ab6d8d990c7a6ea74cc28f18cbf7
       lifecycle_preflight_artifact: lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}
     secrets:
       codex_audit_service_url: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}

--- a/tests/test_drift_workflow_config.py
+++ b/tests/test_drift_workflow_config.py
@@ -19,7 +19,7 @@ def test_drift_workflow_wires_real_pipeline_inputs_and_preflight_bundle() -> Non
     assert "research_panel.csv.gz" in workflow
     assert "market_history.csv.gz" in workflow
     assert "repository: QuantStrategyLab/QuantPlatformKit" in workflow
-    assert "ref: bda6afdab0a2dd693c35d14493176829f4da1231" in workflow
+    assert "ref: 3d14b9697c85ab6d8d990c7a6ea74cc28f18cbf7" in workflow
     assert "python -m pip install --no-deps -e external/QuantPlatformKit" in workflow
     assert "scripts/run_walk_forward_backtest.py" in workflow
     assert '"--list-profiles"' in workflow
@@ -29,7 +29,7 @@ def test_drift_workflow_wires_real_pipeline_inputs_and_preflight_bundle() -> Non
     assert "Upload lifecycle preflight artifact" in workflow
     assert "lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
     assert workflow.count("github.ref == format('refs/heads/{0}', github.event.repository.default_branch)") == 2
-    assert "uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@bda6afdab0a2dd693c35d14493176829f4da1231" in workflow
+    assert "uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@3d14b9697c85ab6d8d990c7a6ea74cc28f18cbf7" in workflow
     assert "strategy_domain: crypto" in workflow
     assert "snapshot_repository: QuantStrategyLab/CryptoLivePoolPipelines" in workflow
     assert "snapshot_checkout_path: external/CryptoLivePoolPipelines" in workflow


### PR DESCRIPTION
## Summary
- pin reusable drift to the QPK revision that permits public snapshot checkout with `github.token`
- retain producer-SHA pinning and optional dedicated-token overrides

## Validation
- `PYTHONPATH=src:../QuantPlatformKit/src python3 -m pytest -q tests/test_drift_workflow_config.py`
- `actionlint .github/workflows/drift-check.yml`
- `git diff --check`