### PR TITLE
chore: pin capacity-aware drift review

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: QuantStrategyLab/QuantPlatformKit
-          ref: fcddef20eea5deb876e739263042acdcb3e9cd1b
+          ref: 4f8465b28a6787d39d21e50f9d95a77841d6ad56
           path: external/QuantPlatformKit
 
       - name: Set up Python
@@ -199,7 +199,7 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@fcddef20eea5deb876e739263042acdcb3e9cd1b
+    uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@4f8465b28a6787d39d21e50f9d95a77841d6ad56
     with:
       strategy_domain: crypto
       caller_event_name: ${{ github.event_name }}
@@ -208,7 +208,7 @@ jobs:
       snapshot_checkout_path: external/CryptoLivePoolPipelines
       snapshot_repository_ref: ${{ needs.preflight_backtests.outputs.snapshot_repository_ref }}
       ai_gateway_service_url: ${{ vars.AI_GATEWAY_SERVICE_URL }}
-      quant_platform_kit_ref: fcddef20eea5deb876e739263042acdcb3e9cd1b
+      quant_platform_kit_ref: 4f8465b28a6787d39d21e50f9d95a77841d6ad56
       lifecycle_preflight_artifact: lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}
     secrets:
       codex_audit_service_url: ${{ secrets.CODEX_AUDIT_SERVICE_URL }}

--- a/tests/test_drift_workflow_config.py
+++ b/tests/test_drift_workflow_config.py
@@ -19,7 +19,7 @@ def test_drift_workflow_wires_real_pipeline_inputs_and_preflight_bundle() -> Non
     assert "research_panel.csv.gz" in workflow
     assert "market_history.csv.gz" in workflow
     assert "repository: QuantStrategyLab/QuantPlatformKit" in workflow
-    assert "ref: fcddef20eea5deb876e739263042acdcb3e9cd1b" in workflow
+    assert "ref: 4f8465b28a6787d39d21e50f9d95a77841d6ad56" in workflow
     assert "python -m pip install --no-deps -e external/QuantPlatformKit" in workflow
     assert "scripts/run_walk_forward_backtest.py" in workflow
     assert '"--list-profiles"' in workflow
@@ -29,7 +29,7 @@ def test_drift_workflow_wires_real_pipeline_inputs_and_preflight_bundle() -> Non
     assert "Upload lifecycle preflight artifact" in workflow
     assert "lifecycle-preflight-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
     assert workflow.count("github.ref == format('refs/heads/{0}', github.event.repository.default_branch)") == 2
-    assert "uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@fcddef20eea5deb876e739263042acdcb3e9cd1b" in workflow
+    assert "uses: QuantStrategyLab/QuantPlatformKit/.github/workflows/reusable-drift-check.yml@4f8465b28a6787d39d21e50f9d95a77841d6ad56" in workflow
     assert "strategy_domain: crypto" in workflow
     assert "snapshot_repository: QuantStrategyLab/CryptoLivePoolPipelines" in workflow
     assert "snapshot_checkout_path: external/CryptoLivePoolPipelines" in workflow


### PR DESCRIPTION
Pins the reusable drift workflow and its QuantPlatformKit checkout to the immutable SHA that carries AIAuditBridge review-capacity classification.

Validation:
- python3 -m pytest -q tests/test_drift_workflow_config.py
- actionlint .github/workflows/drift-check.yml
- git diff --check