### PR TITLE
chore(qsl): adopt compatibility bundle 2026.07.4

### DIFF
--- a/qsl.toml
+++ b/qsl.toml
@@ -2,7 +2,7 @@ tier = "strategy-lib"
 upgrade_ring = "ring_b"
 
 [compat]
-bundle = "2026.07.3"
+bundle = "2026.07.4"
 requires = [
   "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@651c9ac4f37ce6e7fe1bac84dc7646cd5abc9e6e",
 ]

--- a/tests/test_qsl_compat_metadata.py
+++ b/tests/test_qsl_compat_metadata.py
@@ -8,4 +8,4 @@ def test_qsl_compat_metadata_exists_and_bundle() -> None:
     with qsl_path.open("rb") as f:
         data = tomllib.load(f)
 
-    assert data.get("compat", {}).get("bundle") == "2026.07.3", "compat.bundle mismatch"
+    assert data.get("compat", {}).get("bundle") == "2026.07.4", "compat.bundle mismatch"


### PR DESCRIPTION
## Summary
- adopt central QSL compatibility bundle 2026.07.4
- no runtime, order, deploy, or secret changes

## Validation
- metadata-only change; existing repository CI and Codex review gate are required
