### PR TITLE
fix: dismiss all Dependabot review requests

### DIFF
--- a/.github/workflows/dependabot_review_request_cleanup.yml
+++ b/.github/workflows/dependabot_review_request_cleanup.yml
@@ -6,20 +6,14 @@ name: Dismiss Dependabot Review Request
 
 permissions:
   contents: read
-  issues: read
   pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
 
 jobs:
   dismiss-review-request:
     if: >-
       (github.event.pull_request.user.login == 'dependabot[bot]' ||
        github.event.pull_request.user.login == 'app/dependabot') &&
-      github.event.requested_reviewer.login == 'Pigbibi' &&
-      (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot')
+      github.event.requested_reviewer.login == 'Pigbibi'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -42,18 +36,6 @@ jobs:
             echo "No review request for ${REVIEWER}; nothing to dismiss." >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
-
-          latest_request_actor="$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" |
-            jq -sr --arg reviewer "${REVIEWER}" \
-              '[.[][] | select(.event == "review_requested" and .requested_reviewer.login == $reviewer)][-1].actor.login // ""')"
-          case "${latest_request_actor}" in
-            'dependabot[bot]'|'app/dependabot') ;;
-            *)
-              echo "Latest review request was made by ${latest_request_actor:-<unknown>}; preserving it." >> "${GITHUB_STEP_SUMMARY}"
-              exit 0
-              ;;
-          esac
 
           if ! gh api --method DELETE \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \


### PR DESCRIPTION
## Policy

All review requests targeting Pigbibi on Dependabot-authored PRs are intentionally dismissed, including later manual re-requests. Major dependency updates remain open because the existing Dependabot auto-merge workflow excludes semver-major updates, but they no longer generate review-request notifications.

## What changed

- handle review_requested events for both dependabot[bot] and app/dependabot PR authors
- remove the request regardless of the event actor
- keep API failures visible while treating an already-removed request as success
- do not checkout or execute PR code

## Validation

- bash syntax check
- git diff --check