### PR TITLE
chore(deps): align QPK pin to 776fe71e57e2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@92458590a463e7219f0369a3505031ee74414135",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@776fe71e57e2924fcd1c73126f41d244242240bb",
 ]
 
 [tool.setuptools]

--- a/qsl.toml
+++ b/qsl.toml
@@ -4,5 +4,5 @@ upgrade_ring = "ring_b"
 [compat]
 bundle = "2026.07.4"
 requires = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@92458590a463e7219f0369a3505031ee74414135",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@776fe71e57e2924fcd1c73126f41d244242240bb",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,9 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=92458590a463e7219f0369a3505031ee74414135" }]
+requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=776fe71e57e2924fcd1c73126f41d244242240bb" }]
 
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=92458590a463e7219f0369a3505031ee74414135#92458590a463e7219f0369a3505031ee74414135" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=776fe71e57e2924fcd1c73126f41d244242240bb#776fe71e57e2924fcd1c73126f41d244242240bb" }


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `776fe71e57e2`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code