### PR TITLE
chore(deps): align QPK pin to 230854059c11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@b371322b948e4298920a7d8613b155245dcd5f8d",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@230854059c11a3711fed4bd997e3f8a7f37cba32",
 ]
 
 [tool.setuptools]

--- a/qsl.toml
+++ b/qsl.toml
@@ -4,5 +4,5 @@ upgrade_ring = "ring_b"
 [compat]
 bundle = "2026.07.4"
 requires = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@b371322b948e4298920a7d8613b155245dcd5f8d",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@230854059c11a3711fed4bd997e3f8a7f37cba32",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,9 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=b371322b948e4298920a7d8613b155245dcd5f8d" }]
+requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=230854059c11a3711fed4bd997e3f8a7f37cba32" }]
 
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=b371322b948e4298920a7d8613b155245dcd5f8d#b371322b948e4298920a7d8613b155245dcd5f8d" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=230854059c11a3711fed4bd997e3f8a7f37cba32#230854059c11a3711fed4bd997e3f8a7f37cba32" }


### PR DESCRIPTION
## Summary
- 自动将 QPK pin 对齐到 `230854059c11`
- 若仓库使用 `uv.lock`，同步刷新 lockfile

## Test plan
- [ ] Repo CI 转绿

🤖 Generated with Claude Code