### PR TITLE
chore: align QPK pin to 9618b4bd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Shared crypto strategy catalog and implementations"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@9618b4bd8e179760ac174914713598762cab15d7",
 ]
 
 [tool.setuptools]

--- a/qsl.toml
+++ b/qsl.toml
@@ -4,5 +4,5 @@ upgrade_ring = "ring_b"
 [compat]
 bundle = "2026.07.4"
 requires = [
-  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2",
+  "quant-platform-kit @ git+https://github.com/QuantStrategyLab/QuantPlatformKit.git@9618b4bd8e179760ac174914713598762cab15d7",
 ]

--- a/tests/test_qsl_compat_metadata.py
+++ b/tests/test_qsl_compat_metadata.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-QPK_REVISION = "2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2"
+QPK_REVISION = "9618b4bd8e179760ac174914713598762cab15d7"
 QPK_URL = (
     "quant-platform-kit @ git+https://github.com/QuantStrategyLab/"
     f"QuantPlatformKit.git@{QPK_REVISION}"

--- a/uv.lock
+++ b/uv.lock
@@ -11,9 +11,9 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2" }]
+requires-dist = [{ name = "quant-platform-kit", git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=9618b4bd8e179760ac174914713598762cab15d7" }]
 
 [[package]]
 name = "quant-platform-kit"
 version = "0.10.0"
-source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2#2f75b59289ef24ab47a3ed8d522c9ef8d6aea6b2" }
+source = { git = "https://github.com/QuantStrategyLab/QuantPlatformKit.git?rev=9618b4bd8e179760ac174914713598762cab15d7#9618b4bd8e179760ac174914713598762cab15d7" }


### PR DESCRIPTION
## Summary
- align the direct QPK dependency, QSL compatibility metadata, and generated lock to accepted QPK `9618b4bd8e179760ac174914713598762cab15d7`
- update the existing pin-contract test expectation
- change no strategy, mandate, runtime, live manifest, workflow, or production code

## Validation
- tests-first metadata RED then GREEN
- dependency-enabled install and `pip check`
- exact QPK `direct_url.json` provenance
- focused/full suites, lock check, Ruff, actionlint, compileall, package, scope and secret gates
